### PR TITLE
Fix error "variable body is not defined"

### DIFF
--- a/src/Slim/Middleware/Minify.php
+++ b/src/Slim/Middleware/Minify.php
@@ -38,7 +38,7 @@ class Minify extends \Slim\Middleware
 		$this->next->call();
 
 		$res  = $app->response();
-		$squeezedHTML = $res->body();
+		$body = $res->body();
 
 		$search = array('/\n/','/\>[^\S ]+/s','/[^\S ]+\</s','/(\s)+/s');
 		$replace = array(' ','>','<','\\1');


### PR DESCRIPTION
While doing preg_replace, the variable $body was missing because it was named $squeezedHTML. Now it is renamed to $body and getting "undefined variable" error anymore.
