### PR TITLE
Support for JavaScript Comments

### DIFF
--- a/src/Slim/Middleware/Minify.php
+++ b/src/Slim/Middleware/Minify.php
@@ -40,8 +40,8 @@ class Minify extends \Slim\Middleware
 		$res  = $app->response();
 		$body = $res->body();
 
-		$search = array('/\n/','/\>[^\S ]+/s','/[^\S ]+\</s','/(\s)+/s');
-		$replace = array(' ','>','<','\\1');
+		$search = array('/(?:(?:\/\*(?:[^*]|(?:\*+[^*\/]))*\*+\/)|(?:(?<!\:|\\\|\')\/\/.*))/', '/\n/','/\>[^\S ]+/s','/[^\S ]+\</s','/(\s)+/s');
+		$replace = array(' ', ' ','>','<','\\1');
 
 		$squeezedHTML = preg_replace($search, $replace, $body);
 


### PR DESCRIPTION
Support for removal of JavaScript comments, since many inline script snippets are often present in templates.
Without this a section like

```
<script>
console.log(1);
//console.log(2);
console.log(3);
</script>
```

changes to `<script>console.log(1);//console.log(2);console.log(3);</script>` thus effectively commenting out the third `console.log()`
As a solution, I have removed the commented part in output file, which also helps in the cause of minification.
