### PR TITLE
Fixed regex to not replace protocol less urls preceeded by a double quote

### DIFF
--- a/src/Slim/Middleware/Minify.php
+++ b/src/Slim/Middleware/Minify.php
@@ -40,7 +40,7 @@ class Minify extends \Slim\Middleware
 		$res  = $app->response();
 		$body = $res->body();
 
-		$search = array('/(?:(?:\/\*(?:[^*]|(?:\*+[^*\/]))*\*+\/)|(?:(?<!\:|\\\|\')\/\/.*))/', '/\n/','/\>[^\S ]+/s','/[^\S ]+\</s','/(\s)+/s');
+		$search = array('/(?:(?:\/\*(?:[^*]|(?:\*+[^*\/]))*\*+\/)|(?:(?<!\:|\\\|\'|\")\/\/.*))/', '/\n/','/\>[^\S ]+/s','/[^\S ]+\</s','/(\s)+/s');
 		$replace = array(' ', ' ','>','<','\\1');
 
 		$squeezedHTML = preg_replace($search, $replace, $body);


### PR DESCRIPTION
Fixed an issue where having protocol less urls on page would break minification.

Ex:
`<script src="//ajax.aspnetcdn.com/ajax/jquery.validate/1.13.0/jquery.validate.min.js"></script>`
